### PR TITLE
allow defdeps to be optionally prefixed with the #_ (ignore next form) reader macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ you quickly want to analyse and plot some data using
 ## Usage
 
 lein-oneoff scripts usually consist of a single file. Dependencies
-should be stated at the top using the `defdeps` form. Here's an example:
+should be stated at the top using the `defdeps` form. You may
+optionally prefix the `defdeps` form with the reader macro #_ (ignore
+next form). Here's an example:
 
-    (defdeps
+    #_(defdeps
       [[org.clojure/clojure "1.2.0"]
        [compojure "0.5.2"]
        [ring/ring-jetty-adapter "0.3.3"]])
@@ -60,9 +62,10 @@ signature:
 where dependencies should be specified as a vector using the same
 syntax as inside regular leiningen `defproject` form under the
 `:dependencies` key. The second argument is an optional map of
-additional standard `defproject` entries. Please note that not
-all of the available leinigen options make sense for a one-off script
-and might not work correctly.
+additional standard `defproject` entries. Please note that not all of
+the available leinigen options make sense for a one-off script and
+might not work correctly. Adding a `#_` prefix will make it possible
+ignore the `defdeps` form when re-compiling the file in a repl.
 
 One of the entries that can be useful is the `:repositories` entry. Here's
 an example:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-oneoff "0.1.1"
+(defproject lein-oneoff "0.1.2"
   :description "Dependency management for one-off scripts."
   :dev-dependencies [[lein-clojars "0.6.0"]]
   :eval-in-leiningen true)

--- a/src/leiningen/oneoff.clj
+++ b/src/leiningen/oneoff.clj
@@ -82,8 +82,12 @@ of a one-off project."
 (when swank-form-var
   (add-hook swank-form-var oneoff-swank-form-hook))
 
-(defn parse-defdeps [script]
-  (let [form (read-string (slurp script))]
+(defn parse-defdeps
+  "Parse the defdeps form from the script, removing any leading #_
+  reader macro if needed."
+  [script]
+  (let [form (read-string
+              (.replaceFirst (re-matcher #"^ *#_" (slurp script)) ""))]
     (if (= (first form) 'defdeps)
       [(nth form 1) (nth form 2 {})]
       [default-deps {}])))


### PR DESCRIPTION
This makes it possible to re-compile the script in a repl, swank/slime in my case, without errors.
